### PR TITLE
Add escape char to some regexs to improve cross compatibility

### DIFF
--- a/src/regexs/cleaners.ts
+++ b/src/regexs/cleaners.ts
@@ -38,9 +38,9 @@
             ],
           },
         //Only brackets, and title not yet found => title is also in brackets
-          only_brackets:/^\[(?<name>[^[]+)\]$/,
+          only_brackets:/^\[(?<name>[^\[]+)\]$/,
         //Unparsable elements, stating from end
-          unparsable:/(?<unparsable>\[[^[]+?\])/,
+          unparsable:/(?<unparsable>\[[^\[]+?\])/,
       },
 
   }

--- a/src/regexs/lang.ts
+++ b/src/regexs/lang.ts
@@ -8,7 +8,7 @@
         extract:[
           /(?<jp>\b[Jj]apanese [Aa]udio\b)/,
           /(?<en>\b[Ee]nglish [Dd]ub\b)/,
-          /(?<en>\b[[Dd]ubbed [Ee]nglish\b)/,
+          /(?<en>\b[\[Dd]ubbed [Ee]nglish\b)/,
           /(?<multi>\b[Mm]ulti[-_. ][Aa]udio\b)/,
           /(?<multi>\bMULT[Ii]\b)/,
           /(?<jp>\bJap\b|\bJAP\b)(?!-[Ss][Uu][Bb])/,

--- a/src/regexs/processors.ts
+++ b/src/regexs/processors.ts
@@ -29,8 +29,8 @@
             //Replace underscore or dots with spaces
               special_to_space:[
                 /(?<=[a-z])_(?=[A-Z0-9])/g,
-                /(?<=[ A-Za-z0-9一-龯])\.(?=[([A-Za-z一-龯])/g,
-                /(?<=[ A-Za-z一-龯])\.(?=[([A-Za-z0-9一-龯])/g,
+                /(?<=[ A-Za-z0-9一-龯])\.(?=[(\[A-Za-z一-龯])/g,
+                /(?<=[ A-Za-z一-龯])\.(?=[(\[A-Za-z0-9一-龯])/g,
               ],
           },
         //Resolution post-processors


### PR DESCRIPTION
I was trying to port some of this library's functionality to Rust but encountered an issue: some regex wouldn't compile, this was due to most of the Regex engines out there not permiting `[`, `-`, `]` characters inside a character class without escaping them first, but the Javascript engine seems to allow this for some reason. 

These changes *shouldn't* change any functionality, it passed the same amount of tests that it did before, but I spent a whole afternoon hunting this weird phantom issue, so I wanted to PR these changes so anyone else trying to port some functionality won't encounter them.

Thanks for the great library! :)